### PR TITLE
Declare version scheme

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,6 +11,7 @@ ThisBuild / credentials += Credentials(Path.userHome / ".ivy2" / ".credentials")
 ThisBuild / envVars ++= Map("CI_PROJECT_DIR" -> sys.env.getOrElse("CI_PROJECT_DIR", "."))
 ThisBuild / scalaVersion := "2.12.15"
 ThisBuild / libraryDependencySchemes += "org.scala-lang.modules" %% "scala-parser-combinators" % "always"
+ThisBuild / versionScheme := Some("early-semver")
 
 lazy val sbtOps = sys.env
   .get("SBT_OPTS")


### PR DESCRIPTION
Declare the project's version scheme via `versionScheme` sbt setting key.
More on the feature in the [docs](https://www.scala-lang.org/blog/2021/02/16/preventing-version-conflicts-with-versionscheme.html#versionscheme-librarydependencyschemes-and-sbt-150).